### PR TITLE
add custom metric types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps:
 	gometalinter --install
 
 lint:
-	gometalinter ./... --vendor --deadline=10000s --dupl-threshold=150 --disable=gas	
+	gometalinter ./... --vendor --deadline=10000s --dupl-threshold=150 --disable=interfacer	--disable=gas
 
 test: 
 	go test ./...

--- a/client.go
+++ b/client.go
@@ -492,6 +492,11 @@ func (c *PCPClient) writeMetrics() {
 				c.writeSingletonMetric(metric.PCPSingletonMetric)
 				wg.Done()
 			}(metric)
+		case *PCPCounterVector:
+			go func(metric *PCPCounterVector) {
+				c.writeInstanceMetric(metric.PCPInstanceMetric)
+				wg.Done()
+			}(metric)
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -497,6 +497,11 @@ func (c *PCPClient) writeMetrics() {
 				c.writeInstanceMetric(metric.PCPInstanceMetric)
 				wg.Done()
 			}(metric)
+		case *PCPGaugeVector:
+			go func(metric *PCPGaugeVector) {
+				c.writeInstanceMetric(metric.PCPInstanceMetric)
+				wg.Done()
+			}(metric)
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -487,6 +487,11 @@ func (c *PCPClient) writeMetrics() {
 				c.writeSingletonMetric(metric.PCPSingletonMetric)
 				wg.Done()
 			}(metric)
+		case *PCPTimer:
+			go func(metric *PCPTimer) {
+				c.writeSingletonMetric(metric.PCPSingletonMetric)
+				wg.Done()
+			}(metric)
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -482,6 +482,11 @@ func (c *PCPClient) writeMetrics() {
 				c.writeSingletonMetric(metric.PCPSingletonMetric)
 				wg.Done()
 			}(metric)
+		case *PCPGauge:
+			go func(metric *PCPGauge) {
+				c.writeSingletonMetric(metric.PCPSingletonMetric)
+				wg.Done()
+			}(metric)
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -477,6 +477,11 @@ func (c *PCPClient) writeMetrics() {
 				c.writeInstanceMetric(metric)
 				wg.Done()
 			}(metric)
+		case *PCPCounter:
+			go func(metric *PCPCounter) {
+				c.writeSingletonMetric(metric.PCPSingletonMetric)
+				wg.Done()
+			}(metric)
 		}
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -1026,10 +1026,10 @@ func TestCounterVector(t *testing.T) {
 		t.Errorf("cannot set an instance, error: %v", err)
 	}
 
-	if val, err := cv.Val("m1"); val != 10 {
+	if val, verr := cv.Val("m1"); val != 10 {
 		t.Errorf("expected m.1[m1] to be 10, got %v", val)
-	} else if err != nil {
-		t.Errorf("cannot retrieve  m.1[m1] value")
+	} else if verr != nil {
+		t.Errorf("cannot retrieve  m.1[m1] value, error: %v", err)
 	}
 
 	// Inc
@@ -1039,9 +1039,9 @@ func TestCounterVector(t *testing.T) {
 		t.Errorf("cannot inc an instance, error: %v", err)
 	}
 
-	if val, err := cv.Val("m2"); val != 12 {
+	if val, verr := cv.Val("m2"); val != 12 {
 		t.Errorf("expected m.1[m2] to be 12, got %v", val)
-	} else if err != nil {
-		t.Errorf("cannot retrieve  m.1[m2] value")
+	} else if verr != nil {
+		t.Errorf("cannot retrieve  m.1[m2] value, error: %v", err)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -997,3 +997,51 @@ func TestTimer(t *testing.T) {
 
 	matchSingleDump(v, timer, c, t)
 }
+
+func TestCounterVector(t *testing.T) {
+	cv, err := NewPCPCounterVector(map[string]int64{
+		"m1": 1,
+		"m2": 2,
+	}, "m.1")
+
+	if err != nil {
+		t.Errorf("cannot create CounterVector, error: %v", err)
+		return
+	}
+
+	c, err := NewPCPClient("c")
+	if err != nil {
+		t.Errorf("cannot create client, error: %v", err)
+	}
+
+	c.MustRegister(cv)
+
+	c.MustStart()
+	defer c.MustStop()
+
+	// Set
+
+	err = cv.Set(10, "m1")
+	if err != nil {
+		t.Errorf("cannot set an instance, error: %v", err)
+	}
+
+	if val, err := cv.Val("m1"); val != 10 {
+		t.Errorf("expected m.1[m1] to be 10, got %v", val)
+	} else if err != nil {
+		t.Errorf("cannot retrieve  m.1[m1] value")
+	}
+
+	// Inc
+
+	err = cv.Inc(10, "m2")
+	if err != nil {
+		t.Errorf("cannot inc an instance, error: %v", err)
+	}
+
+	if val, err := cv.Val("m2"); val != 12 {
+		t.Errorf("expected m.1[m2] to be 12, got %v", val)
+	} else if err != nil {
+		t.Errorf("cannot retrieve  m.1[m2] value")
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1023,10 +1023,7 @@ func TestCounterVector(t *testing.T) {
 
 	// Set
 
-	err = cv.Set(10, "m1")
-	if err != nil {
-		t.Errorf("cannot set an instance, error: %v", err)
-	}
+	cv.MustSet(10, "m1")
 
 	if val, err = cv.Val("m1"); val != 10 {
 		t.Errorf("expected m.1[m1] to be 10, got %v", val)
@@ -1036,10 +1033,7 @@ func TestCounterVector(t *testing.T) {
 
 	// Inc
 
-	err = cv.Inc(10, "m2")
-	if err != nil {
-		t.Errorf("cannot inc an instance, error: %v", err)
-	}
+	cv.MustInc(10, "m2")
 
 	if val, err = cv.Val("m2"); val != 12 {
 		t.Errorf("expected m.1[m2] to be 12, got %v", val)
@@ -1083,10 +1077,7 @@ func TestGaugeVector(t *testing.T) {
 
 	// Set
 
-	err = g.Set(10, "m1")
-	if err != nil {
-		t.Errorf("cannot set an instance, error: %v", err)
-	}
+	g.MustSet(10, "m1")
 
 	if val, err = g.Val("m1"); val != 10 {
 		t.Errorf("expected m.1[m1] to be 10, got %v", val)
@@ -1096,13 +1087,20 @@ func TestGaugeVector(t *testing.T) {
 
 	// Inc
 
-	err = g.Inc(10, "m2")
-	if err != nil {
-		t.Errorf("cannot inc an instance, error: %v", err)
-	}
+	g.MustInc(10, "m2")
 
 	if val, err = g.Val("m2"); val != 12.4 {
-		t.Errorf("expected m.1[m2] to be 12, got %v", val)
+		t.Errorf("expected m.1[m2] to be 12.4, got %v", val)
+	} else if err != nil {
+		t.Errorf("cannot retrieve m.1[m2] value, error: %v", err)
+	}
+
+	// Dec
+
+	g.MustDec(10, "m2")
+
+	if val, err = g.Val("m2"); val != 2.4 {
+		t.Errorf("expected m.1[m2] to be 2.4, got %v", val)
 	} else if err != nil {
 		t.Errorf("cannot retrieve m.1[m2] value, error: %v", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package speed
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -845,6 +846,10 @@ func TestMMV2InstanceWriting(t *testing.T) {
 	}
 }
 
+func toFixed(v float64, p int) float64 {
+	return float64(uint64(v*math.Pow(10, float64(p)))) / math.Pow(10, float64(p))
+}
+
 func matchSingleDump(expected interface{}, m PCPMetric, c *PCPClient, t *testing.T) {
 	_, _, metrics, values, _, _, strings, err := mmvdump.Dump(c.writer.Bytes())
 	if err != nil {
@@ -1099,7 +1104,7 @@ func TestGaugeVector(t *testing.T) {
 
 	g.MustDec(10, "m2")
 
-	if val, err = g.Val("m2"); val != 2.4 {
+	if val, err = g.Val("m2"); toFixed(val, 5) != 2.4 {
 		t.Errorf("expected m.1[m2] to be 2.4, got %v", val)
 	} else if err != nil {
 		t.Errorf("cannot retrieve m.1[m2] value, error: %v", err)

--- a/client_test.go
+++ b/client_test.go
@@ -843,3 +843,29 @@ func TestMMV2InstanceWriting(t *testing.T) {
 		t.Errorf("expected two strings in the dump")
 	}
 }
+
+func TestCounter(t *testing.T) {
+	c, err := NewPCPClient("test", ProcessFlag)
+	if err != nil {
+		t.Errorf("cannot create client, error: %v", err)
+	}
+
+	m, err := NewPCPCounter(0, "c.1")
+	if err != nil {
+		t.Errorf("cannot create counter, error: %v", err)
+	}
+
+	c.MustRegister(m)
+
+	c.MustStart()
+	defer c.MustStop()
+
+	_, _, metrics, values, _, _, _, err := mmvdump.Dump(c.buffer.Bytes())
+	if err != nil {
+		t.Errorf("cannot get dump: %v", err)
+		return
+	}
+
+	matchMetricsAndValues(metrics, values, c, t)
+}
+

--- a/client_test.go
+++ b/client_test.go
@@ -1019,6 +1019,8 @@ func TestCounterVector(t *testing.T) {
 	c.MustStart()
 	defer c.MustStop()
 
+	var val int64
+
 	// Set
 
 	err = cv.Set(10, "m1")
@@ -1026,10 +1028,10 @@ func TestCounterVector(t *testing.T) {
 		t.Errorf("cannot set an instance, error: %v", err)
 	}
 
-	if val, verr := cv.Val("m1"); val != 10 {
+	if val, err = cv.Val("m1"); val != 10 {
 		t.Errorf("expected m.1[m1] to be 10, got %v", val)
-	} else if verr != nil {
-		t.Errorf("cannot retrieve  m.1[m1] value, error: %v", err)
+	} else if err != nil {
+		t.Errorf("cannot retrieve m.1[m1] value, error: %v", err)
 	}
 
 	// Inc
@@ -1039,9 +1041,69 @@ func TestCounterVector(t *testing.T) {
 		t.Errorf("cannot inc an instance, error: %v", err)
 	}
 
-	if val, verr := cv.Val("m2"); val != 12 {
+	if val, err = cv.Val("m2"); val != 12 {
 		t.Errorf("expected m.1[m2] to be 12, got %v", val)
-	} else if verr != nil {
-		t.Errorf("cannot retrieve  m.1[m2] value, error: %v", err)
+	} else if err != nil {
+		t.Errorf("cannot retrieve m.1[m2] value, error: %v", err)
+	}
+
+	// Up
+
+	cv.Up("m1")
+
+	if val, err = cv.Val("m1"); val != 11 {
+		t.Errorf("expected m.1[m1] to be 11, got %v", val)
+	} else if err != nil {
+		t.Errorf("cannot retrieve m.1[m1] value, error: %v", err)
+	}
+}
+
+func TestGaugeVector(t *testing.T) {
+	g, err := NewPCPGaugeVector(map[string]float64{
+		"m1": 1.2,
+		"m2": 2.4,
+	}, "m.1")
+
+	if err != nil {
+		t.Errorf("cannot create GaugeVector, error: %v", err)
+		return
+	}
+
+	c, err := NewPCPClient("c")
+	if err != nil {
+		t.Errorf("cannot create client, error: %v", err)
+	}
+
+	c.MustRegister(g)
+
+	c.MustStart()
+	defer c.MustStop()
+
+	var val float64
+
+	// Set
+
+	err = g.Set(10, "m1")
+	if err != nil {
+		t.Errorf("cannot set an instance, error: %v", err)
+	}
+
+	if val, err = g.Val("m1"); val != 10 {
+		t.Errorf("expected m.1[m1] to be 10, got %v", val)
+	} else if err != nil {
+		t.Errorf("cannot retrieve m.1[m1] value, error: %v", err)
+	}
+
+	// Inc
+
+	err = g.Inc(10, "m2")
+	if err != nil {
+		t.Errorf("cannot inc an instance, error: %v", err)
+	}
+
+	if val, err = g.Val("m2"); val != 12.4 {
+		t.Errorf("expected m.1[m2] to be 12, got %v", val)
+	} else if err != nil {
+		t.Errorf("cannot retrieve m.1[m2] value, error: %v", err)
 	}
 }

--- a/examples/http_counter/server.go
+++ b/examples/http_counter/server.go
@@ -8,18 +8,13 @@ import (
 	"github.com/performancecopilot/speed"
 )
 
-// TODO: replace the raw metric with a Counter once defined
-
-var metric speed.SingletonMetric
+var metric speed.Counter
 
 func main() {
 	var err error
-	metric, err = speed.NewPCPSingletonMetric(
+	metric, err = speed.NewPCPCounter(
 		0,
 		"http.requests",
-		speed.Int32Type,
-		speed.CounterSemantics,
-		speed.OneUnit,
 		"Number of Requests",
 	)
 	if err != nil {
@@ -49,8 +44,6 @@ func main() {
 }
 
 func handleIncrement(w http.ResponseWriter, r *http.Request) {
-	v := metric.Val().(int32)
-	v++
-	metric.MustSet(v)
+	metric.Up()
 	fmt.Fprintf(w, "incremented\n")
 }

--- a/examples/singleton_counter/main.go
+++ b/examples/singleton_counter/main.go
@@ -1,7 +1,5 @@
 package main
 
-// TODO: update this example with PCPCounterMetric once that is implemented
-
 import (
 	"flag"
 	"fmt"
@@ -15,12 +13,9 @@ var timelimit = flag.Int("time", 60, "number of seconds to run for")
 func main() {
 	flag.Parse()
 
-	metric, err := speed.NewPCPSingletonMetric(
+	metric, err := speed.NewPCPCounter(
 		0,
 		"counter",
-		speed.Int32Type,
-		speed.CounterSemantics,
-		speed.OneUnit,
 		"A Simple Metric",
 	)
 	if err != nil {
@@ -42,9 +37,7 @@ func main() {
 
 	fmt.Println("The metric should be visible as mmv.singletoncounter.counter")
 	for i := 0; i < *timelimit; i++ {
-		v := metric.Val().(int32)
-		v++
-		metric.MustSet(v)
+		metric.Up()
 		time.Sleep(time.Second)
 	}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -802,8 +802,10 @@ type CounterVector interface {
 	Val(string) int64
 
 	Set(int64, string) error
+	MustSet(int64, string)
 
 	Inc(int64, string) error
+	MustInc(int64, string)
 
 	Up(string)
 }
@@ -862,6 +864,13 @@ func (c *PCPCounterVector) Set(val int64, instance string) error {
 	return c.PCPInstanceMetric.SetInstance(instance, val)
 }
 
+// MustSet panics if Set fails
+func (c *PCPCounterVector) MustSet(val int64, instance string) {
+	if err := c.Set(val, instance); err != nil {
+		panic(err)
+	}
+}
+
 // Inc increments the value of a particular instance of PCPCounterVector
 func (c *PCPCounterVector) Inc(inc int64, instance string) error {
 	if inc < 0 {
@@ -880,14 +889,14 @@ func (c *PCPCounterVector) Inc(inc int64, instance string) error {
 	return c.Set(v+inc, instance)
 }
 
-// Up increments the value of a particular instance ny 1
-func (c *PCPCounterVector) Up(instance string) error {
-	v, err := c.Val(instance)
-	if err != nil {
-		return err
+// MustInc panics if Inc fails
+func (c *PCPCounterVector) MustInc(inc int64, instance string) {
+	if err := c.Inc(inc, instance); err != nil {
+		panic(err)
 	}
-
-	return c.Set(v+1, instance)
 }
+
+// Up increments the value of a particular instance ny 1
+func (c *PCPCounterVector) Up(instance string) { c.MustInc(1, instance) }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/metrics.go
+++ b/metrics.go
@@ -617,6 +617,10 @@ func (c *PCPCounter) Set(val int64) error {
 
 // Inc increases the stored counter's value by the passed increment
 func (c *PCPCounter) Inc(val int64) error {
+	if val < 0 {
+		return errors.New("cannot decrement a counter")
+	}
+
 	v := c.Val()
 	v += val
 	return c.Set(v)

--- a/metrics.go
+++ b/metrics.go
@@ -785,7 +785,10 @@ func (t *PCPTimer) Stop() (float64, error) {
 	t.Unlock()
 
 	v := t.PCPSingletonMetric.Val().(float64)
-	t.PCPSingletonMetric.Set(v + inc)
+	err := t.PCPSingletonMetric.Set(v + inc)
 
+	if err != nil {
+		return -1, err
+	}
 	return v + inc, nil
 }

--- a/metrics.go
+++ b/metrics.go
@@ -284,6 +284,9 @@ type PCPMetric interface {
 type Counter interface {
 	Metric
 
+	Val() int64
+	Set(int64) error
+
 	Inc(int64) error
 	MustInc(int64)
 

--- a/registry.go
+++ b/registry.go
@@ -213,7 +213,10 @@ func (r *PCPRegistry) AddMetric(m Metric) error {
 
 	// if it is an indom metric
 	if pcpm.Indom() != nil && !r.HasInstanceDomain(pcpm.Indom().Name()) {
-		return errors.New("the metric's instance domain is not defined for current registry")
+		err := r.AddInstanceDomain(pcpm.Indom())
+		if err != nil {
+			return err
+		}
 	}
 
 	r.metricslock.Lock()


### PR DESCRIPTION
Potential types to consider

- [x]  __Counter__
- [x] __Timer__ (__Elapsed__)
- [x] __Gauge__

~~__Derive__~~
~~__Rate__ (__Meter__)~~

`Rate` and `Derive` are supported implicitly by PCP, just set the reporting rate at the time unit (seconds, minutes, hours...) and set semantics to `InstantSemantics` to get Rate and `CounterSemantics` to get Derived. `Gauge` is a shorthand to get a `float64` metric with `InstantSemantics`, while `Counter` implements a `uint64` metric with `CounterSemantics`.

~~__Histogram__~~
~~__Summary__~~

to be considered after #28 

~~__Reservoir__~~

couldn't find a real world example of applying reservoir sampling on metric values, why add a value if the probability of it having any real impact just keeps diminishing

see:

- https://godoc.org/github.com/heroku/instruments
- http://metrics.dropwizard.io/3.1.0/manual/core/
- https://prometheus.io/docs/concepts/metric_types/