### PR TITLE
travis: install latest release automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.6.4
-  - 1.7.5
-  - 1.8
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
   - tip
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
     - environment:
       GOVERSION: 1.7.5
     - environment:
-      GOVERSION: 1.8
+      GOVERSION: 1.8.3
 
 install:
   - rmdir c:\go /s /q


### PR DESCRIPTION
go 1.8.3 was released.

This will enable travis to install and test latest minor release without having to update the file with every new go release

@natoscott please review