### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/performancecopilot/speed
 go 1.12
 
 require (
-	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
 	github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712
 	github.com/pkg/errors v0.8.0
 )


### PR DESCRIPTION
github.com/codahale/hdrhistogram: github.com/codahale/hdrhistogram@v1.0.0: parsing go.mod:
        module declares its path as: github.com/HdrHistogram/hdrhistogram-go
                but was required as: github.com/codahale/hdrhistogram