### PR TITLE
Fix semantic import versioning

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/performancecopilot/speed/bytewriter"
+	"github.com/performancecopilot/speed/v4/bytewriter"
 )
 
 // byte lengths of different components in an mmv file

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/HdrHistogram/hdrhistogram-go"
-	"github.com/performancecopilot/speed/mmvdump"
+	"github.com/performancecopilot/speed/v4/mmvdump"
 )
 
 func TestMmvFileLocation(t *testing.T) {

--- a/examples/acme/main.go
+++ b/examples/acme/main.go
@@ -21,7 +21,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 var runforever bool

--- a/examples/basic_histogram/main.go
+++ b/examples/basic_histogram/main.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 func main() {

--- a/examples/download/main.go
+++ b/examples/download/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 type sink int

--- a/examples/http_counter/server.go
+++ b/examples/http_counter/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 var metric speed.Counter

--- a/examples/instance_string/main.go
+++ b/examples/instance_string/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 var timelimit = flag.Int("time", 60, "number of seconds to run for")

--- a/examples/runtime/main.go
+++ b/examples/runtime/main.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 // refresh interval

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 func main() {

--- a/examples/simple_string_metric/main.go
+++ b/examples/simple_string_metric/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 var timelimit = flag.Int("time", 60, "number of seconds to run for")

--- a/examples/singleton_counter/main.go
+++ b/examples/singleton_counter/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 var timelimit = flag.Int("time", 60, "number of seconds to run for")

--- a/examples/singleton_string/main.go
+++ b/examples/singleton_string/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/performancecopilot/speed"
+	"github.com/performancecopilot/speed/v4"
 )
 
 var timelimit = flag.Int("time", 60, "number of seconds to run for")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/performancecopilot/speed
+module github.com/performancecopilot/speed/v4
 
 go 1.12
 

--- a/metrics.go
+++ b/metrics.go
@@ -10,7 +10,7 @@ import (
 	histogram "github.com/HdrHistogram/hdrhistogram-go"
 	"github.com/pkg/errors"
 
-	"github.com/performancecopilot/speed/bytewriter"
+	"github.com/performancecopilot/speed/v4/bytewriter"
 )
 
 // MetricType is an enumerated type representing all valid types for a metric.

--- a/mmvdump/cmd/mmvdump/main.go
+++ b/mmvdump/cmd/mmvdump/main.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/performancecopilot/speed/mmvdump"
+	"github.com/performancecopilot/speed/v4/mmvdump"
 )
 
 func main() {


### PR DESCRIPTION
Unfortunately, I completely missed the fact that this library is already past v1 and that the module name is not properly versioned (according to Go module practices). That causes some issues when trying to import this module.

This PR adds a v4 version to the module name (unfortunately, that's the only way to fix this problem) that would require tagging a v4.0.0 version.

The alternative is for projects to import commits directly, so all is not lost.

Read more here: https://blog.golang.org/v2-go-modules